### PR TITLE
Download modules from our mirror instead of cloning

### DIFF
--- a/cfbs/commands.py
+++ b/cfbs/commands.py
@@ -730,6 +730,7 @@ def print_module_info(data):
         "repo",
         "index",
         "commit",
+        "subdirectory",
         "dependencies",
         "added_by",
         "description",

--- a/test/test_showinfo.py
+++ b/test/test_showinfo.py
@@ -31,6 +31,7 @@ By: https:\/\/github.com\/cfengine
 Tags: wip, untested
 Repo: https:\/\/github.com\/cfengine\/modules
 Commit: [a-zA-Z0-9]+
+Subdirectory: management\/autorun
 Added By: ./foo/main.cf
 Description: Enable autorun functionality
 """,


### PR DESCRIPTION
Cloning the repositories with modules is not a good idea,
especially because the repositories can be deleted by their
owners or some other issues can happen. Instead, when a module is
added to the index, we archive it in our mirror and then use the
archive in `cfbs build`, verifying that the checksum matches the
expected value stored in cfbs-index/master/versions.json.

Ticket: CFE-3780
Changelog: 'cfbs build' now downloads module archives instead of cloning repositories