### PR TITLE
Removed dependency on cf-remote, for now

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,17 @@ pip install cfbs
 
 (or `sudo pip3 install cfbs` or whatever works with Python 3 on your system).
 
+It is also **recommended** to install `cf-remote` if you want to deploy the policy set to remote hub(s):
+
+```
+pip install cf-remote
+```
+
 ### Dependencies
 
 `cfbs` is implemented in Python and has some dependencies on python version and libraries:
 
 * Python 3.6 or newer
-* `cf-remote` and its dependencies
-  * Installed automatically by `pip`
 
 Additionally, some command line tools are required (not installed by pip):
 

--- a/cfbs/index.py
+++ b/cfbs/index.py
@@ -2,8 +2,6 @@
 import os
 import sys
 
-from cf_remote.paths import cfengine_dir
-
 from cfbs.utils import (
     cfbs_dir,
     user_error,
@@ -19,6 +17,7 @@ from cfbs.utils import (
     rm,
     cp,
     sh,
+    cfengine_dir,
 )
 
 

--- a/cfbs/utils.py
+++ b/cfbs/utils.py
@@ -8,7 +8,6 @@ import hashlib
 import urllib
 from collections import OrderedDict
 from shutil import rmtree
-from cf_remote.paths import cfengine_dir
 
 import requests
 
@@ -156,6 +155,15 @@ def cfbs_filename() -> str:
 
 def is_cfbs_repo() -> bool:
     return os.path.isfile(cfbs_filename())
+
+
+def path_append(dir, subdir):
+    dir = os.path.abspath(os.path.expanduser(dir))
+    return dir if not subdir else os.path.join(dir, subdir)
+
+
+def cfengine_dir(subdir=None):
+    return path_append("~/.cfengine/", subdir)
 
 
 def cfbs_dir(append=None) -> str:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 requests>=2.25.1
-cf-remote>=0.2.0

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,5 @@ setuptools.setup(
     },
     install_requires=[
       "requests >= 2.25.1",
-      "cf-remote >= 0.2.0",
     ],
 )


### PR DESCRIPTION
We only used a very small part of it in the code, and it was
blocking our progress with making cfbs compatible with python
3.5. We might reintroduce it at a later time.