### PR TITLE
Added a better error message during build when a json file is misspelled

### DIFF
--- a/cfbs/commands.py
+++ b/cfbs/commands.py
@@ -867,9 +867,10 @@ def build_step(module, step, max_length):
         if dst in [".", "./"]:
             dst = ""
         print("%s json '%s' 'masterfiles/%s'" % (prefix, src, dst))
+        if not os.path.isfile(os.path.join(source, src)):
+            user_error("'%s' is not a file" % src)
         src, dst = os.path.join(source, src), os.path.join(destination, dst)
         extras, original = read_json(src), read_json(dst)
-        assert extras is not None
         if not extras:
             print("Warning: '%s' looks empty, adding nothing" % os.path.basename(src))
         if original:


### PR DESCRIPTION
Before:

```
002 autorun     : json 'defz.json' 'masterfiles/def.json'
Traceback (most recent call last):
  File "/home/olehermanse/.local/bin/cfbs", line 8, in <module>
    sys.exit(main())
  File "/home/olehermanse/.local/lib/python3.8/site-packages/cfbs/main.py", line 145, in main
    return commands.build_command()
  File "/home/olehermanse/.local/lib/python3.8/site-packages/cfbs/commands.py", line 949, in build_command
    build_steps()
  File "/home/olehermanse/.local/lib/python3.8/site-packages/cfbs/commands.py", line 931, in build_steps
    build_step(module, step, module_name_length)
  File "/home/olehermanse/.local/lib/python3.8/site-packages/cfbs/commands.py", line 872, in build_step
    assert extras is not None
AssertionError
$
```

After:

```
002 autorun     : json 'defz.json' 'masterfiles/def.json'
Error: 'defz.json' is not a file
$
```

Ticket: CFE-3843