### PR TITLE
Fixed status command for locally added policy files

### DIFF
--- a/cfbs/commands.py
+++ b/cfbs/commands.py
@@ -138,10 +138,15 @@ def status_command() -> int:
     max_length = longest_module_name()
     counter = 1
     for m in modules:
-        path = get_download_path(m)
-        status = "Downloaded" if os.path.exists(path) else "Not downloaded"
+        if m["name"].startswith("./"):
+            status = "Copied"
+            commit = pad_right("local", 40)
+        else:
+            path = get_download_path(m)
+            status = "Downloaded" if os.path.exists(path) else "Not downloaded"
+            commit = m["commit"]
         name = pad_right(m["name"], max_length)
-        print("%03d %s @ %s (%s)" % (counter, name, m["commit"], status))
+        print("%03d %s @ %s (%s)" % (counter, name, commit, status))
         counter += 1
 
     return 0

--- a/cfbs/commands.py
+++ b/cfbs/commands.py
@@ -134,6 +134,8 @@ def status_command() -> int:
     print("File:        %s" % cfbs_filename())
 
     modules = definition["build"]
+    if not modules:
+        return 0
     print("\nModules:")
     max_length = longest_module_name()
     counter = 1

--- a/test/shell/010_local_add.sh
+++ b/test/shell/010_local_add.sh
@@ -6,7 +6,9 @@ cd ./tmp/
 touch cfbs.json && rm cfbs.json
 
 cfbs init
+cfbs status
 cfbs add mpf
+cfbs status
 echo '
 bundle agent test_bundle
 {

--- a/test/shell/010_local_add.sh
+++ b/test/shell/010_local_add.sh
@@ -1,0 +1,24 @@
+set -e
+set -x
+cd test
+mkdir -p ./tmp/
+cd ./tmp/
+touch cfbs.json && rm cfbs.json
+
+cfbs init
+cfbs add mpf
+echo '
+bundle agent test_bundle
+{
+  meta:
+    "tags" slist => { "autorun" };
+  reports:
+    "test";
+}
+' > test_policy.cf
+cfbs add ./test_policy.cf
+grep '"name": "autorun"' cfbs.json
+grep '"name": "./test_policy.cf"' cfbs.json
+cfbs status
+cfbs build
+ls out/masterfiles/services/autorun/test_policy.cf

--- a/test/shell/all.sh
+++ b/test/shell/all.sh
@@ -12,3 +12,4 @@ bash test/shell/006_search.sh
 bash test/shell/007_install.sh
 bash test/shell/008_remove.sh
 bash test/shell/009_clean.sh
+bash test/shell/010_local_add.sh


### PR DESCRIPTION
Format matches that of cfbs build;

```
$ cfbs status
Name:        Example
Description: Example description
File:        cfbs.json

Modules:
001 masterfiles @ 5c7dc5b43088e259a94de4e5a9f17c0ce9781a0f (Downloaded)
002 autorun     @ c3b7329b240cf7ad062a0a64ee8b607af2cb912a (Downloaded)
003 ./test.cf   @ local                                    (Copied)
```