### PR TITLE
Sort modules and their attributes as desired in 'cfbs pretty'

### DIFF
--- a/cfbs/main.py
+++ b/cfbs/main.py
@@ -53,6 +53,11 @@ def get_args():
         default=None,
         help="Expected checksum of the downloaded file",
     )
+    parser.add_argument(
+        "--keep-order",
+        help="Keep order of items in the JSON in 'cfbs pretty'",
+        action="store_true",
+    )
 
     args = parser.parse_args()
     if args.command == "help":
@@ -117,7 +122,7 @@ Warning: The --non-interactive option is only meant for testing (!)
     if args.command == "search":
         return commands.search_command(args.args, index_path=args.index)
     if args.command == "pretty":
-        return commands.pretty_command(args.args, args.check)
+        return commands.pretty_command(args.args, args.check, args.keep_order)
     if args.command == "validate":
         return commands.validate_command(index_path=args.index)
     if args.command in ("info", "show"):

--- a/cfbs/pretty.py
+++ b/cfbs/pretty.py
@@ -1,35 +1,139 @@
 import json
+import re
 from collections import OrderedDict
 
 
-def pretty_check_file(filename):
+def _children_sort(child, name, sorting_rules):
+    """Recursively sort child objects in a JSON object.
+
+    :param child: child object to start with
+    :type child: OrderedDict
+    :param name: name of `child` in its parent object (`None` for the top-level object)
+    :type name: str or None
+    :param sorting_rules: rules for sorting child objects (see below)
+    :type sorting_rules: dict
+
+    The `sorting_rules` must be of the following form:
+
+    ```
+    {
+      "child_name_or_regex": (child_name_key_fn, sorting_rules_inside_child),
+      ...
+    }
+    ```
+
+    where:
+    - `child_name_or_regex` is either a string name (key) of a child object,
+      or a regular expression matching child object names (keys),
+    - `child_name_key_fn` is a key function passed to :func:`sorted` to
+      sort the (grand)child objects inside the matching child object(s), and
+    - `sorting_rules_inside_child` define the sorting rules inside the matching
+      child object(s) using the same structure.
+
+    So the `sorting_rules` dictionary must follow the same structure as the JSON
+    object being sorted. For example the following rules:
+
+    ```
+    {
+        None: (lambda child_item: child_item[0],
+               {
+                   "modules": (lambda child_item: child_item[0],
+                              {
+                                  re.compile(r".*"): (lambda child_item: len(child_item[0]), None)
+                              })
+               })
+    }
+    ```
+
+    sorts the child objects in the given top-level (`name == None`) JSON object
+    alphabetically by their name, then only inside the `"modules"` object all
+    its (grand)child objects are sorted the same way and inside all (`".*"`)
+    those (grand)child objects, their (grand-grand)child objects by the lengths
+    of their names and then the recursion stops (`None` given as
+    `sorting_rules_inside_child`).
+
+    The input JSON is thus supposed to look like this:
+
+    ```
+    {
+      "something": ...,
+      "modules": {
+        "mod1": {
+          "attr1": ...,
+        },
+        ...
+      },
+      "something else",
+      ...
+    }
+    ```
+
+    and the sorting will sort `"something"` `"modules"` and `"something else"`
+    alphabetically, then the modules inside `"modules"` alphabetically and then
+    the attributes of the modules by their length. No sorting will happen inside
+    `"something"` and `"something else"` as well as in the attributes.
+
+    .. note::
+       Only JSON objects (dictionaries) are sorted by this function, arrays are ignored.
+
+    """
+    assert type(child) == OrderedDict
+
+    rules = None
+    if name in sorting_rules.keys():
+        rules = sorting_rules[name]
+    else:
+        for child_key_re in sorting_rules.keys():
+            if re.match(child_key_re, name):
+                rules = sorting_rules[child_key_re]
+                break
+
+    if rules is None:
+        return
+
+    child_key_fn = rules[0]
+    if child_key_fn is not None:
+        for key, value in sorted(child.items(), key=child_key_fn):
+            child.move_to_end(key)
+
+    child_sorting_rules = rules[1]
+    if child_sorting_rules is not None:
+        for child_key, child_value in child.items():
+            if type(child_value) == OrderedDict:
+                _children_sort(child_value, child_key, child_sorting_rules)
+
+
+def pretty_check_file(filename, sorting_rules=None):
     with open(filename) as f:
         s = f.read()
     o = json.loads(s, object_pairs_hook=OrderedDict)
-    return s == pretty(o) + "\n"
+    return s == pretty(o, sorting_rules) + "\n"
 
 
-def pretty_check_string(s):
+def pretty_check_string(s, sorting_rules=None):
     o = json.loads(s, object_pairs_hook=OrderedDict)
-    return s == pretty(o)
+    return s == pretty(o, sorting_rules)
 
 
-def pretty_file(filename):
+def pretty_file(filename, sorting_rules=None):
     with open(filename) as f:
-        data = pretty_string(f.read())
+        data = pretty_string(f.read(), sorting_rules)
     with open(filename, "w") as f:
         f.write(data)
         f.write("\n")
 
 
-def pretty_string(s):
+def pretty_string(s, sorting_rules=None):
     s = json.loads(s, object_pairs_hook=OrderedDict)
-    return pretty(s)
+    return pretty(s, sorting_rules)
 
 
-def pretty(o):
+def pretty(o, sorting_rules=None):
     MAX_LEN = 80
     INDENT_SIZE = 2
+
+    if sorting_rules is not None:
+        _children_sort(o, None, sorting_rules)
 
     def _should_wrap(parent):
         assert isinstance(parent, (tuple, list, dict))


### PR DESCRIPTION
https://github.com/cfengine/build-index/blob/master/CONTRIBUTING.md#publishing-your-module-for-others-to-reuse
defines ordering for the modules attributes so `cfbs pretty`
should make sure they are in order.

Ticket: CFE-3834
Changelog: 'cfbs pretty' now sorts modules and their attributes