### PR TITLE
CFE-3812: cfbs init now prompts user whether to use default masterfiles

### DIFF
--- a/cfbs/commands.py
+++ b/cfbs/commands.py
@@ -210,7 +210,7 @@ def init_command(index=None, non_interactive=False) -> int:
         to_add = "masterfiles"
     else:
         to_add = prompt_user(
-            "Specify policy set to use instead (or skip if empty)", default=""
+            "Specify policy set to use instead (empty to skip)", default=""
         )
 
     if to_add:

--- a/cfbs/commands.py
+++ b/cfbs/commands.py
@@ -127,7 +127,7 @@ def init_command(index=None, non_interactive=False) -> int:
         "name": name,
         "type": "policy-set",  # TODO: Prompt whether user wants to make a module
         "description": description,
-        "build": [],  # TODO: Prompt what masterfile user wants to add
+        "build": [],
     }
     if index:
         config["index"] = index
@@ -193,7 +193,28 @@ def init_command(index=None, non_interactive=False) -> int:
     print(
         "Initialized an empty project called '{}' in '{}'".format(name, cfbs_filename())
     )
-    print("To add your first module, type: cfbs add masterfiles")
+
+    """
+    The CFBSConfig instance was initally created in main(). Back then
+    cfbs.json did not exist, thus the instance is empty. By manually deleting
+    this instance, a new instance will be created loading the now existing
+    cfbs.json.
+    """
+    CFBSConfig.instance = None
+
+    if prompt_user(
+        "Do you wish to build on top of the default policy set, masterfiles? (Recommended)",
+        choices=YES_NO_CHOICES,
+        default="yes",
+    ) in ("yes", "y"):
+        to_add = "masterfiles"
+    else:
+        to_add = prompt_user(
+            "Specify policy set to use instead (or skip if empty)", default=""
+        )
+
+    if to_add:
+        return add_command([to_add])
 
     return 0
 

--- a/test/shell/002_add.sh
+++ b/test/shell/002_add.sh
@@ -7,5 +7,5 @@ touch cfbs.json && rm cfbs.json
 rm -rf .git
 
 cfbs --non-interactive init
-cfbs --non-interactive add masterfiles
+cfbs --non-interactive add autorun
 grep masterfiles cfbs.json

--- a/test/shell/003_download.sh
+++ b/test/shell/003_download.sh
@@ -7,7 +7,6 @@ touch cfbs.json && rm cfbs.json
 rm -rf .git
 
 cfbs --non-interactive init
-cfbs --non-interactive add masterfiles
 cfbs download
 
 ls ~/.cfengine/cfbs/downloads/*

--- a/test/shell/004_build.sh
+++ b/test/shell/004_build.sh
@@ -7,7 +7,6 @@ touch cfbs.json && rm cfbs.json
 rm -rf .git
 
 cfbs --non-interactive init
-cfbs --non-interactive add mpf
 cfbs --non-interactive add autorun
 cfbs --non-interactive add systemd
 cfbs --non-interactive add git

--- a/test/shell/005_alias.sh
+++ b/test/shell/005_alias.sh
@@ -7,7 +7,7 @@ touch cfbs.json && rm cfbs.json
 rm -rf .git
 
 cfbs --non-interactive init
-cfbs --non-interactive add mpf > output.log
+cfbs --non-interactive add groups > output.log
 
 grep "alias" output.log
 grep "Added module" output.log

--- a/test/shell/007_install.sh
+++ b/test/shell/007_install.sh
@@ -16,7 +16,6 @@ rm -rf .git
 rm -rf ~/.cfagent/inputs/
 
 cfbs --non-interactive init
-cfbs --non-interactive add mpf
 cfbs --non-interactive add autorun
 cfbs install
 

--- a/test/shell/008_remove.sh
+++ b/test/shell/008_remove.sh
@@ -7,7 +7,6 @@ touch cfbs.json && rm cfbs.json
 rm -rf .git
 
 cfbs --non-interactive init
-cfbs --non-interactive add masterfiles
 grep '"name": "masterfiles"' cfbs.json
 cfbs --non-interactive remove masterfiles --non-interactive
 ! grep '"name": "masterfiles"' cfbs.json

--- a/test/shell/010_local_add.sh
+++ b/test/shell/010_local_add.sh
@@ -8,8 +8,6 @@ rm -rf .git
 
 cfbs --non-interactive init
 cfbs status
-cfbs --non-interactive add mpf
-cfbs status
 echo '
 bundle agent test_bundle
 {

--- a/test/shell/013_add_url_commit.sh
+++ b/test/shell/013_add_url_commit.sh
@@ -7,7 +7,6 @@ touch cfbs.json && rm cfbs.json
 rm -rf .git
 
 cfbs --non-interactive init
-cfbs --non-interactive add masterfiles
 cfbs --non-interactive add https://github.com/basvandervlies/cf_surfsara_lib@09e07dda690f5806d5f17be8e71d9fdcc51bbdf1
 
 grep https://github.com/basvandervlies/cf_surfsara_lib cfbs.json

--- a/test/shell/016_add_folders.sh
+++ b/test/shell/016_add_folders.sh
@@ -45,9 +45,6 @@ echo 'Hello
 cfbs --non-interactive init
 cfbs status
 
-cfbs --non-interactive add mpf
-cfbs status
-
 cfbs --non-interactive add ./one
 cfbs --non-interactive add ./two/
 cfbs status


### PR DESCRIPTION
The cfbs init command now prompts users whether or not they want to use
the default masterfiles policy framework. If the user says no, they're
prompted with which masterfiles they want to add, allowing them to skip
if empty.

Ticket: CFE-3812
Changelog: Title
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>