### PR TITLE
ENT-8573 & ENT-8579: cfbs update now supports specifying modules

### DIFF
--- a/cfbs/git_magic.py
+++ b/cfbs/git_magic.py
@@ -14,8 +14,15 @@ def git_commit_maybe_prompt(commit_msg, non_interactive, scope="all"):
     edit_commit_msg = False
 
     if not non_interactive:
+        prompt = "The default commit message is '{}' - edit it?".format(commit_msg)
+        if "\n" in commit_msg:
+            prompt = "The default commit message is:\n\n"
+            for line in commit_msg.split("\n"):
+                prompt += "\n" if line == "" else "\t" + line + "\n"
+            prompt += "\nEdit it?"
+
         ans = prompt_user(
-            "The default commit message is '{}' - edit it?".format(commit_msg),
+            prompt,
             choices=YES_NO_CHOICES,
             default="no",
         )

--- a/cfbs/main.py
+++ b/cfbs/main.py
@@ -109,7 +109,7 @@ def main() -> int:
         "clean",
         "update",
     ):
-        user_error("The option --non-interactive is not for cfbs " % (args.command))
+        user_error("The option --non-interactive is not for cfbs %s" % (args.command))
 
     if args.non_interactive:
         print(

--- a/cfbs/main.py
+++ b/cfbs/main.py
@@ -165,7 +165,7 @@ Warning: The --non-interactive option is only meant for testing (!)
     if args.command == "install":
         return commands.install_command(args.args)
     if args.command == "update":
-        return commands.update_command()
+        return commands.update_command(args.args)
 
     _get_arg_parser().print_help()
     user_error("Command '%s' not found" % args.command)

--- a/test/shell/011_update.sh
+++ b/test/shell/011_update.sh
@@ -6,24 +6,9 @@ cd ./tmp/
 touch cfbs.json && rm cfbs.json
 rm -rf .git
 
-echo '
-{
-  "name": "Example",
-  "type": "policy-set",
-  "description": "Example description",
-  "build": [
-    {
-      "name": "promise-type-ansible",
-      "version": "0.0.0",
-      "commit": "invalid",
-      "added_by": "cfbs add",
-      "steps": []
-    }
-  ],
-  "git": false
-}
-' > cfbs.json
-
+cfbs --non-interactive init
+cfbs --non-interactive add promise-type-ansible@0.1.1
+cfbs --non-interactive update promise-type-ansible@0.1.0
 cfbs --non-interactive update
 
 # This is not perfect, it relies on the JSON formatting, and it doesn't check
@@ -60,7 +45,6 @@ cat cfbs.json | grep -F "subdirectory" | grep -F "libraries/python/"
 cat cfbs.json | grep -F "added_by" | grep -F "promise-type-ansible"
 cat cfbs.json | grep -F "steps" | grep -F "copy cfengine.py modules/promises/"
 
-cfbs --non-interactive add mpf
 cfbs status
 cfbs build
 


### PR DESCRIPTION
cfbs update now supports specifying module name (or name and version) by
using the following format `cfbs update [NAME[@VERSION]]...`.

Ticket: ENT-8573 and ENT-8579
Changelog: Body
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>