### PR TITLE
Follow-ups on ENT-8573 & ENT-8579

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 __pycache__/
 cfbs.egg-info
 cfbs/VERSION
+*.pyc
 
 # Node / npm:
 node_modules/

--- a/cfbs/cfbs_config.py
+++ b/cfbs/cfbs_config.py
@@ -17,6 +17,7 @@ from cfbs.cfbs_json import CFBSJson
 from cfbs.module import Module
 
 
+# Legacy; do not use. Use the 'Result' namedtuple instead.
 class CFBSReturnWithoutCommit(Exception):
     def __init__(self, r):
         self.retval = r

--- a/cfbs/cfbs_json.py
+++ b/cfbs/cfbs_json.py
@@ -94,3 +94,9 @@ class CFBSJson:
 
     def _module_is_in_build(self, module):
         return module["name"] in (m["name"] for m in self["build"])
+
+    def get_module_from_build(self, module):
+        for m in self["build"]:
+            if m["name"] == module:
+                return m
+        return None

--- a/cfbs/git_magic.py
+++ b/cfbs/git_magic.py
@@ -4,10 +4,14 @@ Here it's okay to depend on other parts of the CFBS codebase,
 do prompts, etc.
 """
 
+from collections import namedtuple
 from cfbs.prompts import YES_NO_CHOICES, prompt_user
 from cfbs.cfbs_config import CFBSConfig, CFBSReturnWithoutCommit
 from cfbs.git import git_commit, git_discard_changes_in_file, CFBSGitError
 from functools import partial
+
+
+Result = namedtuple("Result", ["rc", "commit", "msg"])
 
 
 def git_commit_maybe_prompt(commit_msg, non_interactive, scope="all"):
@@ -40,15 +44,16 @@ def with_git_commit(
     def decorator(fn):
         def decorated_fn(*args, **kwargs):
             try:
-                ret = fn(*args, **kwargs)
+                result = fn(*args, **kwargs)
             except CFBSReturnWithoutCommit as e:
+                # Legacy; do not use. Use the 'Result' tuple instead.
                 return e.retval
+            ret, should_commit, msg = (
+                result if isinstance(result, Result) else (result, True, None)
+            )
 
-            config = CFBSConfig.get_instance()
-            if not config.get("git", False):
-                return ret
-
-            if ret in successful_returns:
+            # Message from the namedtuple overrides message from decorator
+            if not msg:
                 if positional_args_lambdas:
                     positional_args = (
                         l_fn(args, kwargs) for l_fn in positional_args_lambdas
@@ -57,20 +62,28 @@ def with_git_commit(
                 else:
                     msg = commit_msg
 
+            if not should_commit:
+                return ret
+
+            config = CFBSConfig.get_instance()
+            if not config.get("git", False):
+                return ret
+
+            if ret not in successful_returns:
+                return ret
+
+            try:
+                git_commit_maybe_prompt(msg, config.non_interactive, files_to_commit)
+            except CFBSGitError as e:
+                print(str(e))
                 try:
-                    git_commit_maybe_prompt(
-                        msg, config.non_interactive, files_to_commit
-                    )
+                    for file_name in files_to_commit:
+                        git_discard_changes_in_file(file_name)
                 except CFBSGitError as e:
                     print(str(e))
-                    try:
-                        for file_name in files_to_commit:
-                            git_discard_changes_in_file(file_name)
-                    except CFBSGitError as e:
-                        print(str(e))
-                    else:
-                        print("Failed to commit changes, discarding them...")
-                        return failed_return
+                else:
+                    print("Failed to commit changes, discarding them...")
+                    return failed_return
             return ret
 
         return decorated_fn


### PR DESCRIPTION
Follow-ups from https://github.com/cfengine/cfbs/pull/111

With the new Result namedtuple we can override the commit message during command execution.

Output with one update:
```
$ cfbs update
The default commit message is 'Update module 'promise-type-groups' to version 0.1.3' - edit it? [yes/y/NO/n] 
Committing using git:

[master 8a71ec6] Update module 'promise-type-groups' to version 0.1.3
 1 file changed, 2 insertions(+), 2 deletions(-)

```

Output with more than one update:
```
$ cfbs update
The default commit message is:

	Updated 2 modules

	 - Updated module 'promise-type-groups' to version 0.1.3
	 - Updated module 'promise-type-git' to version 0.1.1

Edit it? [yes/y/NO/n] 
Committing using git:

[master b2d3ea8] Updated 2 modules
 1 file changed, 4 insertions(+), 4 deletions(-)

```

