### PR TITLE
Ignore CFBSReturnWithoutCommit from _clean_unused_modules() in remove…

### DIFF
--- a/cfbs/commands.py
+++ b/cfbs/commands.py
@@ -350,7 +350,10 @@ def remove_command(to_remove: list):
 
     config.save()
     if num_removed:
-        _clean_unused_modules(config)
+        try:
+            _clean_unused_modules(config)
+        except CFBSReturnWithoutCommit:
+            pass
         return 0
     else:
         raise CFBSReturnWithoutCommit(0)


### PR DESCRIPTION
…_command

If some modules are removed explicitly, the changes should be
committed even if there are no unused modules to remove.