### PR TITLE
ENT-7914: Added --ignore-versions-json argument for build command

### DIFF
--- a/cfbs/args.py
+++ b/cfbs/args.py
@@ -79,4 +79,9 @@ def _get_arg_parser():
         "--git-commit-message",
         help="Specify git commit message",
     )
+    parser.add_argument(
+        "--ignore-versions-json",
+        help="Ignore versions.json. Necessary in case of a custom index or testing changes to the default index.",
+        action="store_true",
+    )
     return parser

--- a/cfbs/commands.py
+++ b/cfbs/commands.py
@@ -589,7 +589,9 @@ def validate_command():
     return 0
 
 
-def _download_dependencies(config, prefer_offline=False, redownload=False):
+def _download_dependencies(
+    config, prefer_offline=False, redownload=False, ignore_versions=False
+):
     # TODO: This function should be split in 2:
     #       1. Code for downloading things into ~/.cfengine
     #       2. Code for copying things into ./out
@@ -621,7 +623,7 @@ def _download_dependencies(config, prefer_offline=False, redownload=False):
         if not os.path.exists(module_dir):
             if url.endswith(SUPPORTED_ARCHIVES):
                 fetch_archive(url, commit)
-            elif "index" in module:
+            elif "index" in module or ignore_versions:
                 sh("git clone %s %s" % (url, commit_dir))
                 sh("(cd %s && git checkout %s)" % (commit_dir, commit))
             else:
@@ -650,15 +652,15 @@ def _download_dependencies(config, prefer_offline=False, redownload=False):
         counter += 1
 
 
-def download_command(force):
+def download_command(force, ignore_versions=False):
     config = CFBSConfig.get_instance()
-    _download_dependencies(config, redownload=force)
+    _download_dependencies(config, redownload=force, ignore_versions=ignore_versions)
 
 
-def build_command() -> int:
+def build_command(ignore_versions=False) -> int:
     config = CFBSConfig.get_instance()
     init_out_folder()
-    _download_dependencies(config, prefer_offline=True)
+    _download_dependencies(config, prefer_offline=True, ignore_versions=ignore_versions)
     perform_build_steps(config)
 
 

--- a/cfbs/main.py
+++ b/cfbs/main.py
@@ -104,7 +104,7 @@ Warning: The --non-interactive option is only meant for testing (!)
     if args.command == "download":
         return commands.download_command(args.force)
     if args.command == "build":
-        return commands.build_command()
+        return commands.build_command(ignore_versions=args.ignore_versions_json)
     if args.command == "install":
         return commands.install_command(args.args)
     if args.command == "update":


### PR DESCRIPTION
Allows use of custom index or testing changes to default index
by ignoring versions.json.

Ticket: ENT-7914
Changelog: title