### PR TITLE
ENT-9351: Added ability to download modules added by URL

### DIFF
--- a/cfbs/commands.py
+++ b/cfbs/commands.py
@@ -623,7 +623,10 @@ def _download_dependencies(
         if not os.path.exists(module_dir):
             if url.endswith(SUPPORTED_ARCHIVES):
                 fetch_archive(url, commit)
-            elif "index" in module or ignore_versions:
+            # a couple of cases where there will not be an archive available:
+            # - using an alternate index (index property in module data)
+            # - added by URL instead of name (no version property in module data)
+            elif "index" in module or not "version" in module or ignore_versions:
                 sh("git clone %s %s" % (url, commit_dir))
                 sh("(cd %s && git checkout %s)" % (commit_dir, commit))
             else:


### PR DESCRIPTION
Key off the absence of a "version" property in the module reference in cfbs.json to know to git clone instead of trying to download and checksum the archive.

Ticket: ENT-9351
Changelog: title