### PR TITLE
Fix type error bug in `cfbs set-input` command

### DIFF
--- a/cfbs/commands.py
+++ b/cfbs/commands.py
@@ -1023,7 +1023,7 @@ def set_input_command(name, infile):
         return 1
     log.debug("Input data for module '%s': %s" % (name, pretty(data)))
 
-    def _compare_dict(a, b, ignore={}):
+    def _compare_dict(a, b, ignore=set()):
         assert isinstance(a, dict) and isinstance(b, dict)
         if set(a.keys()) != set(b.keys()) - ignore:
             return False
@@ -1051,7 +1051,7 @@ def set_input_command(name, infile):
         if (
             not isinstance(a, dict)
             or not isinstance(b, dict)
-            or not _compare_dict(a, b, ignore={"response"})
+            or not _compare_dict(a, b, ignore=set({"response"}))
         ):
             log.error(
                 "Input data for module '%s' does not conform with input definition"

--- a/tests/shell/031_get_set_input_pipe.sh
+++ b/tests/shell/031_get_set_input_pipe.sh
@@ -1,0 +1,42 @@
+set -e
+set -x
+cd tests/
+mkdir -p ./tmp/
+cd ./tmp/
+touch cfbs.json && rm cfbs.json
+rm -rf .git
+rm -rf create-single-file
+
+cfbs --non-interactive init
+cfbs --non-interactive add delete-files@0.0.1
+echo '[
+  {
+    "type": "list",
+    "variable": "files",
+    "namespace": "delete_files",
+    "bundle": "delete_files",
+    "label": "Files",
+    "subtype": [
+      {
+        "key": "path",
+        "type": "string",
+        "label": "Path",
+        "question": "Path to file"
+      },
+      {
+        "key": "why",
+        "type": "string",
+        "label": "Why",
+        "question": "Why should this file be deleted?",
+        "default": "Unknown"
+      }
+    ],
+    "while": "Specify another file you want deleted on your hosts?",
+    "response": [
+      { "path": "/tmp/test1", "why": "Test 1" },
+      { "path": "/tmp/test2", "why": "Test 2" }
+    ]
+  }
+]' | cfbs set-input delete-files -
+
+cfbs get-input delete-files - | cfbs set-input delete-files -

--- a/tests/shell/all.sh
+++ b/tests/shell/all.sh
@@ -33,5 +33,6 @@ bash tests/shell/027_init_masterfiles_version_master.sh
 bash tests/shell/028_init_masterfiles_version_3.18.2.sh
 bash tests/shell/029_init_masterfiles_version_3.18.1-1.sh
 bash tests/shell/030_get_set_input.sh
+bash tests/shell/031_get_set_input_pipe.sh
 
 echo "All cfbs shell tests completed successfully!"


### PR DESCRIPTION
Fixed bug where operands of type `dict` and `set` where used with the `-` operator.

Ticket: None
Changelog: None
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>