### PR TITLE
CFE-4099: Fixed bug where order of keys breaks set-input

### DIFF
--- a/cfbs/commands.py
+++ b/cfbs/commands.py
@@ -1023,9 +1023,10 @@ def set_input_command(name, infile):
         return 1
     log.debug("Input data for module '%s': %s" % (name, pretty(data)))
 
-    def _compare_dict(a, b, ignore=set()):
+    def _compare_dict(a, b, ignore=None):
+        assert ignore is None or isinstance(ignore, set)
         assert isinstance(a, dict) and isinstance(b, dict)
-        if set(a.keys()) != set(b.keys()) - ignore:
+        if set(a.keys()) != set(b.keys()) - (set() if ignore is None else ignore):
             return False
         # Avoid code duplication by converting the values of the two dicts
         # into two lists in the same order and compare the lists instead

--- a/cfbs/commands.py
+++ b/cfbs/commands.py
@@ -1039,12 +1039,18 @@ def set_input_command(name, infile):
         for x, y in zip(a, b):
             if type(x) != type(y):
                 return False
-            if isinstance(x, dict) and not _compare_dict(x, y):
-                return False
-            if isinstance(x, list) and not _compare_list(x, y):
-                return False
-            if x != y:
-                return False
+            if isinstance(x, dict):
+                if not _compare_dict(x, y):
+                    return False
+            elif isinstance(x, list):
+                if not _compare_list(x, y):
+                    return False
+            else:
+                assert isinstance(
+                    x, (int, float, str, bool, None)
+                ), "Illegal value type"
+                if x != y:
+                    return False
         return True
 
     for a, b in zip(spec, data):

--- a/tests/shell/031_get_set_input_pipe.sh
+++ b/tests/shell/031_get_set_input_pipe.sh
@@ -5,7 +5,7 @@ mkdir -p ./tmp/
 cd ./tmp/
 touch cfbs.json && rm cfbs.json
 rm -rf .git
-rm -rf create-single-file
+rm -rf delete-files
 
 cfbs --non-interactive init
 cfbs --non-interactive add delete-files@0.0.1

--- a/tests/shell/032_get_set_input_unordered.sh
+++ b/tests/shell/032_get_set_input_unordered.sh
@@ -1,0 +1,42 @@
+set -e
+set -x
+cd tests/
+mkdir -p ./tmp/
+cd ./tmp/
+touch cfbs.json && rm cfbs.json
+rm -rf .git
+rm -rf delete-files
+
+cfbs --non-interactive init
+cfbs --non-interactive add delete-files@0.0.1
+echo '[
+  {
+    "bundle": "delete_files",
+    "label": "Files",
+    "namespace": "delete_files",
+    "response": [
+      {
+        "path": "/tmp/test",
+        "why": "no tests, please"
+      }
+    ],
+    "subtype": [
+      {
+        "key": "path",
+        "label": "Path",
+        "question": "Path to file",
+        "type": "string"
+      },
+      {
+        "default": "Unknown",
+        "key": "why",
+        "label": "Why",
+        "question": "Why should this file be deleted?",
+        "type": "string"
+      }
+    ],
+    "type": "list",
+    "variable": "files",
+    "while": "Specify another file you want deleted on your hosts?"
+  }
+]' | cfbs --log=debug set-input delete-files -

--- a/tests/shell/all.sh
+++ b/tests/shell/all.sh
@@ -34,5 +34,6 @@ bash tests/shell/028_init_masterfiles_version_3.18.2.sh
 bash tests/shell/029_init_masterfiles_version_3.18.1-1.sh
 bash tests/shell/030_get_set_input.sh
 bash tests/shell/031_get_set_input_pipe.sh
+bash tests/shell/032_get_set_input_unordered.sh
 
 echo "All cfbs shell tests completed successfully!"


### PR DESCRIPTION
Fix bug where order of keys breaks set-input

Fixed bug where changing the order of keys when using `cfbs set-input`
causes it to error with the following error message `ERROR: Input data
for module 'delete-files' does not conform with input definition`

Ticket: CFE-4099
Changelog: None
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>