### PR TITLE
Fixed commit message in the `cfbs add` command

### DIFF
--- a/cfbs/cfbs_config.py
+++ b/cfbs/cfbs_config.py
@@ -396,6 +396,9 @@ class CFBSConfig(CFBSJson):
             msg = "Added %d modules\n" % count + msg
         else:
             msg = msg[4:]  # Remove the '\n - ' part of the message
+            # If there are multiple lines, add an additional newline between
+            # the short- & long description.
+            msg = msg.replace("\n", "\n\n", 1)
 
         changes_made = count > 0
         return Result(0, changes_made, msg, files)


### PR DESCRIPTION
Fixed issue where commit message when adding a single module with input
does not separate the long- & short description with an additional
newline.

Commit message when adding a single module with input now looks like
this:
```
Added module 'delete-files'

 - Added input for module 'delete-files'
```

Ticket: None
Changelog: None
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>