### PR TITLE
ENT-9710: Switched to pythonic mkdir -p

### DIFF
--- a/cfbs/utils.py
+++ b/cfbs/utils.py
@@ -42,7 +42,7 @@ def sh(cmd: str, directory=None):
 
 
 def mkdir(path: str):
-    sh("mkdir -p %s" % path)
+    os.makedirs(path, exist_ok=True)
 
 
 def touch(path: str):


### PR DESCRIPTION
We don't want to use sh() for cfbs commands which
are used in the Mission Portal Build application.

Ticket: ENT-9710