### PR TITLE
 ENT-8980: The prompt for adding all modules now has yes/y/no/n options, like the other prompts

### DIFF
--- a/cfbs/cfbs_config.py
+++ b/cfbs/cfbs_config.py
@@ -137,8 +137,11 @@ class CFBSConfig(CFBSJson):
             if not any(modules):
                 user_error("no modules available, nothing to do")
             if not self.non_interactive:
-                answer = input(
-                    "Do you want to add all %d of them? [y/N] " % (len(modules))
+                answer = prompt_user(
+                    non_interactive=self.non_interactive,
+                    prompt="Do you want to add all %d of them?" % (len(modules)),
+                    choices=YES_NO_CHOICES,
+                    default="no",
                 )
                 if answer.lower() not in ("y", "yes"):
                     return

--- a/cfbs/prompts.py
+++ b/cfbs/prompts.py
@@ -34,7 +34,7 @@ def prompt_user(non_interactive, prompt, choices=None, default=None):
         if answer == "":
             answer = default
         elif choices and answer not in choices and answer.lower() not in choices:
-            print("Invalid value entered, must ve one of: %s" % "/".join(choices))
+            print("Invalid value entered, must be one of: %s" % "/".join(choices))
             answer = None
 
     return answer


### PR DESCRIPTION
Changed hardcoded print of [y/N] to [yes/y/NO/n] using helper function to be consistent

Ticket: ENT-8980