### PR TITLE
ENT-10944: cfbs build/download: Added validation and error messages

### DIFF
--- a/cfbs/build.py
+++ b/cfbs/build.py
@@ -18,6 +18,85 @@ from cfbs.utils import (
 from cfbs.pretty import pretty, pretty_file
 
 
+def validate_config_for_build_field(config):
+    """Validate that neccessary fields are in the config for the build/download commands to work"""
+    if not "build" in config:
+        user_error(
+            'A "build" field is missing in ./cfbs.json'
+            + " - The 'cfbs build' command loops through all modules in this list to find build steps to perform"
+        )
+    if type(config["build"]) is not list:
+        user_error(
+            'The "build" field in ./cfbs.json must be a list (of modules involved in the build)'
+        )
+    if config["build"] == []:
+        user_error(
+            "The \"build\" field in ./cfbs.json is empty - add modules with 'cfbs add'"
+        )
+    for index, module in enumerate(config["build"]):
+        if not "name" in module:
+            user_error(
+                "The module at index "
+                + str(index)
+                + ' of "build" in ./cfbs.json is missing a "name"'
+            )
+        name = module["name"]
+        if type(name) is not str:
+            user_error(
+                "The module at index "
+                + str(index)
+                + ' of "build" in ./cfbs.json has a name which is not a string'
+            )
+        if not name:
+            user_error(
+                "The module at index "
+                + str(index)
+                + ' of "build" in ./cfbs.json has an empty name'
+            )
+        if (
+            not "steps" in module
+            or type(module["steps"]) is not list
+            or module["steps"] == []
+        ):
+            user_error(
+                'Build steps are missing for the "'
+                + name
+                + '" module in ./cfbs.json - the "steps" field must have a non-empty list of steps to perform (strings)'
+            )
+
+        steps = module["steps"]
+        not_strings = len([step for step in steps if type(step) is not str])
+        if not_strings == 1:
+            user_error(
+                "The module '"
+                + name
+                + '\' in "build" in ./cfbs.json has 1 step which is not a string'
+            )
+        if not_strings > 1:
+            user_error(
+                "The module '"
+                + name
+                + '\' in "build" in ./cfbs.json has '
+                + str(not_strings)
+                + " steps which are not strings"
+            )
+        empty_strings = len([step for step in steps if step == ""])
+        if empty_strings == 1:
+            user_error(
+                "The module '"
+                + name
+                + '\' in "build" in ./cfbs.json has 1 step which is empty'
+            )
+        if empty_strings > 1:
+            user_error(
+                "The module '"
+                + name
+                + '\' in "build" in ./cfbs.json has '
+                + str(empty_strings)
+                + " steps which are empty"
+            )
+
+
 def init_out_folder():
     rm("out", missing_ok=True)
     mkdir("out")

--- a/cfbs/commands.py
+++ b/cfbs/commands.py
@@ -31,7 +31,11 @@ from cfbs.utils import (
 
 from cfbs.args import get_args
 from cfbs.pretty import pretty, pretty_check_file, pretty_file
-from cfbs.build import init_out_folder, perform_build_steps
+from cfbs.build import (
+    init_out_folder,
+    perform_build_steps,
+    validate_config_for_build_field,
+)
 from cfbs.cfbs_config import CFBSConfig, CFBSReturnWithoutCommit
 from cfbs.validate import CFBSIndexException, validate_index
 from cfbs.internal_file_management import (
@@ -904,12 +908,14 @@ def _download_dependencies(
 @cfbs_command("download")
 def download_command(force, ignore_versions=False):
     config = CFBSConfig.get_instance()
+    validate_config_for_build_field(config)
     _download_dependencies(config, redownload=force, ignore_versions=ignore_versions)
 
 
 @cfbs_command("build")
 def build_command(ignore_versions=False) -> int:
     config = CFBSConfig.get_instance()
+    validate_config_for_build_field(config)
     init_out_folder()
     _download_dependencies(config, prefer_offline=True, ignore_versions=ignore_versions)
     perform_build_steps(config)

--- a/tests/shell/026_init_no_masterfiles.sh
+++ b/tests/shell/026_init_no_masterfiles.sh
@@ -8,4 +8,5 @@ rm -rf .git
 
 cfbs --non-interactive init --masterfiles=no
 !( grep '"name": "masterfiles"' cfbs.json )
-cfbs build
+cfbs status
+!( cfbs build )


### PR DESCRIPTION
Added many helpful error messages to tell the user what
is wrong with their cfbs.json (why they cannot run cfbs
build or cfbs download).

The config must have a build field, with a list of modules,
each module must have a name, a non-empty list of steps,
each step must be a non-empty string, etc.

Ticket: ENT-10944