### PR TITLE
Stopped adding modules with empty subdirectory fields

### DIFF
--- a/cfbs/cfbs_config.py
+++ b/cfbs/cfbs_config.py
@@ -291,6 +291,8 @@ class CFBSConfig(CFBSJson):
         for module in modules:
             name = module["name"]
             assert name not in (m["name"] for m in self["build"])
+            if "subdirectory" in module and module["subdirectory"] == "":
+                del module["subdirectory"]
             if self.index.custom_index != None:
                 module["index"] = self.index.custom_index
             self["build"].append(module)


### PR DESCRIPTION
Most of the time, this happens becuase you add a specific version of a
module and the versions.json file has empty string for "subdirectory"
for all of the modules which are not using subdirectories.