### PR TITLE
Fixed issues when adding modules to missing build key

### DIFF
--- a/cfbs/cfbs_config.py
+++ b/cfbs/cfbs_config.py
@@ -102,6 +102,8 @@ class CFBSConfig(CFBSJson):
         if "dependencies" in module:
             for dep in module["dependencies"]:
                 self.add_with_dependencies(dep, remote_config, module["name"])
+        if "build" not in self._data:
+            self._data["build"] = []
         self._data["build"].append(module)
         if dependent:
             print("Added module: %s (Dependency of %s)" % (module["name"], dependent))
@@ -351,7 +353,7 @@ class CFBSConfig(CFBSJson):
         if not to_add:
             user_error("Must specify at least one module to add")
 
-        before = {m["name"] for m in self["build"]}
+        before = {m["name"] for m in self.get("build", [])}
 
         if to_add[0].endswith(SUPPORTED_ARCHIVES) or to_add[0].startswith(
             ("https://", "git://", "ssh://")

--- a/cfbs/cfbs_json.py
+++ b/cfbs/cfbs_json.py
@@ -165,7 +165,7 @@ class CFBSJson:
         return None
 
     def _module_is_in_build(self, module):
-        return module["name"] in (m["name"] for m in self["build"])
+        return "build" in self and module["name"] in (m["name"] for m in self["build"])
 
     def get_module_from_build(self, module):
         for m in self["build"]:


### PR DESCRIPTION
"build" key is only required for the "policy-set" type.
However, we still want users to be able to use the "build"
key and "cfbs build" in all projects, so we need to add the
key for them when necessary, and account for the fact that
the key might be missing.
