### PR TITLE
Allowed numbers in namespaces in module input

### DIFF
--- a/cfbs/validate.py
+++ b/cfbs/validate.py
@@ -346,10 +346,10 @@ def _validate_module_object(context, name, module, config):
                     '"%s" is not an acceptable variable name, must match regex "[a-z_]+"'
                     % input_element["variable"],
                 )
-            if not re.fullmatch(r"[a-z_]+", input_element["namespace"]):
+            if not re.fullmatch(r"[a-z_][a-z0-9_]+", input_element["namespace"]):
                 raise CFBSValidationError(
                     name,
-                    '"%s" is not an acceptable namespace, must match regex "[a-z_]+"'
+                    '"%s" is not an acceptable namespace, must match regex "[a-z_][a-z0-9_]+"'
                     % input_element["namespace"],
                 )
             if not re.fullmatch(r"[a-z_]+", input_element["bundle"]):


### PR DESCRIPTION
We wanted to make a `rhel_7_stig` namespace, which seems reasonable
so let's allow it.

I've seen other langauges not allowing identifiers to start with a number
to make things less ambiguous, so let's do that.

For example, `rhel_7_stig` is considered an acceptable namespace, while
`123`, `100_000`, and `1M` are not, since they look like values / numbers.