### PR TITLE
Stopped printing cfbs.json content as part of cfbs init

### DIFF
--- a/cfbs/commands.py
+++ b/cfbs/commands.py
@@ -211,7 +211,6 @@ def init_command(index=None, masterfiles=None, non_interactive=False) -> int:
     config["git"] = do_git
 
     data = pretty(config, CFBS_DEFAULT_SORTING_RULES) + "\n"
-    print(data)
     with open(cfbs_filename(), "w") as f:
         f.write(data)
     assert is_cfbs_repo()


### PR DESCRIPTION
This was an accidental print statement left in by me when I
was fixing the sorting of this JSON file (specifically the
git field).