### PR TITLE
ENT-9556: `cfbs status` now displays module versions in addition to commit hashes

### DIFF
--- a/cfbs/build.py
+++ b/cfbs/build.py
@@ -231,7 +231,7 @@ def perform_build_steps(config) -> int:
         user_error("No 'build' key found in the configuration")
         return 1
     print("\nSteps:")
-    module_name_length = config.longest_module_name()
+    module_name_length = config.longest_module_key_length("name")
     for module in config.get("build", []):
         for step in module["steps"]:
             _perform_build_step(module, step, module_name_length)

--- a/cfbs/cfbs_config.py
+++ b/cfbs/cfbs_config.py
@@ -80,8 +80,8 @@ class CFBSConfig(CFBSJson):
         with open(self.path, "w") as f:
             f.write(data)
 
-    def longest_module_name(self) -> int:
-        return max((len(m["name"]) for m in self["build"])) if self.get("build") else 0
+    def longest_module_key_length(self, key) -> int:
+        return max((len(m[key]) for m in self["build"])) if self.get("build") else 0
 
     def add_with_dependencies(self, module, remote_config=None, dependent=None):
         if type(module) is list:

--- a/cfbs/cfbs_config.py
+++ b/cfbs/cfbs_config.py
@@ -81,7 +81,7 @@ class CFBSConfig(CFBSJson):
             f.write(data)
 
     def longest_module_key_length(self, key) -> int:
-        return max((len(m[key]) for m in self["build"])) if self.get("build") else 0
+        return max((len(m.get(key, "")) for m in self["build"])) if self.get("build") else 0
 
     def add_with_dependencies(self, module, remote_config=None, dependent=None):
         if type(module) is list:

--- a/cfbs/cfbs_config.py
+++ b/cfbs/cfbs_config.py
@@ -81,7 +81,11 @@ class CFBSConfig(CFBSJson):
             f.write(data)
 
     def longest_module_key_length(self, key) -> int:
-        return max((len(m.get(key, "")) for m in self["build"])) if self.get("build") else 0
+        return (
+            max((len(m.get(key, "")) for m in self["build"]))
+            if self.get("build")
+            else 0
+        )
 
     def add_with_dependencies(self, module, remote_config=None, dependent=None):
         if type(module) is list:

--- a/cfbs/commands.py
+++ b/cfbs/commands.py
@@ -302,7 +302,7 @@ def status_command() -> int:
     if not modules:
         return 0
     print("\nModules:")
-    max_length = config.longest_module_name()
+    max_length = config.longest_module_key_length("name")
     counter = 1
     for m in modules:
         if m["name"].startswith("./"):
@@ -843,7 +843,7 @@ def _download_dependencies(
     #       2. Code for copying things into ./out
     print("\nModules:")
     counter = 1
-    max_length = config.longest_module_name()
+    max_length = config.longest_module_key_length("name")
     downloads = os.path.join(cfbs_dir(), "downloads")
     for module in config.get("build", []):
         name = module["name"]

--- a/cfbs/commands.py
+++ b/cfbs/commands.py
@@ -302,18 +302,28 @@ def status_command() -> int:
     if not modules:
         return 0
     print("\nModules:")
-    max_length = config.longest_module_key_length("name")
+    max_name_length = config.longest_module_key_length("name")
+    max_version_length = config.longest_module_key_length("version")
     counter = 1
     for m in modules:
         if m["name"].startswith("./"):
             status = "Copied"
-            commit = pad_right("local", 40)
+            version = "local"
+            commit = pad_right("", 40)
         else:
             path = get_download_path(m)
             status = "Downloaded" if os.path.exists(path) else "Not downloaded"
+            version = m.get("version", "")
             commit = m["commit"]
-        name = pad_right(m["name"], max_length)
-        print("%03d %s @ %s (%s)" % (counter, name, commit, status))
+        name = pad_right(m["name"], max_name_length)
+        version = pad_right(version, max_version_length)
+        version_with_commit = version + " "
+        if m["name"].startswith("./"):
+            version_with_commit += " "
+        else:
+            version_with_commit += "/"
+        version_with_commit += " " + commit
+        print("%03d %s @ %s (%s)" % (counter, name, version_with_commit, status))
         counter += 1
 
     return 0


### PR DESCRIPTION
Before:
```
$ cfbs status
Name:        Example project
Description: Example description
File:        cfbs.json

Modules:
001 masterfiles               @ 691c6b2d11eefcfcda2e2b0d1de33440cec112a9 (Downloaded)
002 autorun                   @ c3b7329b240cf7ad062a0a64ee8b607af2cb912a (Not downloaded)
003 ./policy-module-template/ @ local                                    (Copied)
```

After:
```
$ cfbs status
Name:        Example project
Description: Example description
File:        cfbs.json

Modules:
001 masterfiles               @ 3.21.5 / 691c6b2d11eefcfcda2e2b0d1de33440cec112a9 (Downloaded)
002 autorun                   @ 1.0.1  / c3b7329b240cf7ad062a0a64ee8b607af2cb912a (Not downloaded)
003 ./policy-module-template/ @ local                                             (Copied)
```