### PR TITLE
ENT-11437: `cfbs init` no longer displays a traceback when `git` is not found

### DIFF
--- a/cfbs/commands.py
+++ b/cfbs/commands.py
@@ -53,6 +53,7 @@ from cfbs.internal_file_management import (
 )
 from cfbs.index import _VERSION_INDEX, Index
 from cfbs.git import (
+    check_git_exists,
     is_git_repo,
     git_commit,
     git_get_config,
@@ -178,6 +179,12 @@ def init_command(index=None, masterfiles=None, non_interactive=False) -> int:
         do_git = True if do_git == "yes" else False
 
     if do_git is True:
+        try:
+            check_git_exists()
+        except FileNotFoundError as e:
+            print("Command 'git' was not found")
+            return 1
+
         user_name = get_args().git_user_name
         if not user_name:
             user_name = git_get_config("user.name")

--- a/cfbs/commands.py
+++ b/cfbs/commands.py
@@ -53,7 +53,7 @@ from cfbs.internal_file_management import (
 )
 from cfbs.index import _VERSION_INDEX, Index
 from cfbs.git import (
-    check_git_exists,
+    git_exists,
     is_git_repo,
     git_commit,
     git_get_config,
@@ -179,9 +179,7 @@ def init_command(index=None, masterfiles=None, non_interactive=False) -> int:
         do_git = True if do_git == "yes" else False
 
     if do_git is True:
-        try:
-            check_git_exists()
-        except FileNotFoundError as e:
+        if not git_exists():
             print("Command 'git' was not found")
             return 1
 

--- a/cfbs/git.py
+++ b/cfbs/git.py
@@ -18,11 +18,12 @@ class CFBSGitError(Exception):
     pass
 
 
-def check_git_exists():
+def git_exists():
     try:
         check_call(["git", "--version"], stdout=DEVNULL)
-    except CalledProcessError as cpe:
-        raise CFBSGitError("'git' was not found") from cpe
+        return True
+    except FileNotFoundError:
+        return False
 
 
 def ls_remote(remote, branch):

--- a/cfbs/git.py
+++ b/cfbs/git.py
@@ -18,6 +18,13 @@ class CFBSGitError(Exception):
     pass
 
 
+def check_git_exists():
+    try:
+        check_call(["git", "--version"], stdout=DEVNULL)
+    except CalledProcessError as cpe:
+        raise CFBSGitError("'git' was not found") from cpe
+
+
 def ls_remote(remote, branch):
     """Returns the hash of the commit that the current HEAD of a given branch
     on a given remote is pointing to.


### PR DESCRIPTION
Changelog: Title

Ticket: ENT-11437