### PR TITLE
Standardize whitespace when generating manpage

### DIFF
--- a/cfbs/args.py
+++ b/cfbs/args.py
@@ -79,9 +79,17 @@ class YesNoToBool(argparse.Action):
 
 
 @cache
-def get_arg_parser():
+def get_arg_parser(whitespace_for_manual=False):
     command_list = commands.get_command_names()
-    parser = argparse.ArgumentParser(prog="cfbs", description="CFEngine Build System.")
+    CFBS_DESCRIPTION = "CFEngine Build System."
+    if whitespace_for_manual:
+        parser = argparse.ArgumentParser(
+            prog="cfbs",
+            description=CFBS_DESCRIPTION,
+            formatter_class=argparse.RawTextHelpFormatter,
+        )
+    else:
+        parser = argparse.ArgumentParser(prog="cfbs", description=CFBS_DESCRIPTION)
     parser.add_argument(
         "command",
         metavar="cmd",

--- a/cfbs/man_generator.py
+++ b/cfbs/man_generator.py
@@ -11,7 +11,7 @@ except ImportError:
 
 
 def generate_man_page():
-    manpage = Manpage(get_arg_parser())
+    manpage = Manpage(get_arg_parser(whitespace_for_manual=True))
     manpage.manual = "CFEngine Build System manual"
     manpage.description = (
         "combines multiple modules into 1 policy set to deploy on your infrastructure. "


### PR DESCRIPTION
Previously, generating manpage could result in varying whitespace, as by default, argparse.py looks at the `COLUMNS` environment variable to determine line length.