### PR TITLE
Use the same flake8 command in legacy Python tests as in regular tests

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -73,10 +73,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Lint with flake8
         run: |
-          # stop the build if there are Python syntax errors or undefined names
-          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+          flake8 . --ignore=E203,W503,E722,E731 --max-complexity=100 --max-line-length=160
       - name: Test with pytest
         run: |
           pytest


### PR DESCRIPTION
The legacy Python tests did not actually fail on flake8 errors like the regular tests, as 47b29d18e9d926954beabb265e54354f65586454 was applied only to the regular tests flake8 call