### PR TITLE
CFE-4571: Even prettier cfbs pretty

### DIFF
--- a/cfbs/pretty.py
+++ b/cfbs/pretty.py
@@ -3,6 +3,9 @@ import re
 from copy import copy
 from collections import OrderedDict
 
+MAX_LEN = 80
+INDENT_SIZE = 2
+
 # Globals for the keys in cfbs.json and their order
 # Used for validation and prettifying / sorting.
 TOP_LEVEL_KEYS = ("name", "description", "type", "index", "git", "provides", "build")
@@ -216,95 +219,96 @@ def pretty_string(s, sorting_rules=None):
     return pretty(s, sorting_rules)
 
 
-def pretty(o, sorting_rules=None):
-    MAX_LEN = 80
-    INDENT_SIZE = 2
+def _should_wrap(parent, indent):
+    assert isinstance(parent, (tuple, list, dict))
+    # We should wrap the top level collection
+    if indent == 0:
+        return True
+    if isinstance(parent, dict):
+        parent = parent.values()
 
+    count = 0
+    for child in parent:
+        if isinstance(child, (tuple, list, dict)):
+            if len(child) >= 2:
+                count += 1
+    return count >= 2
+
+
+def _encode_list(lst, indent, cursor):
+    if not lst:
+        return "[]"
+    if not _should_wrap(lst, indent):
+        buf = json.dumps(lst)
+        assert "\n" not in buf
+        if indent + cursor + len(buf) <= MAX_LEN:
+            return buf
+
+    indent += INDENT_SIZE
+    buf = "[\n" + " " * indent
+    first = True
+    for value in lst:
+        if first:
+            first = False
+        else:
+            buf += ",\n" + " " * indent
+        buf += _encode(value, indent, 0)
+    indent -= INDENT_SIZE
+    buf += "\n" + " " * indent + "]"
+
+    return buf
+
+
+def _encode_dict(dct, indent, cursor):
+    if not dct:
+        return "{}"
+    if not _should_wrap(dct, indent):
+        buf = json.dumps(dct)
+        buf = "{ " + buf[1:-1] + " }"
+        assert "\n" not in buf
+        if indent + cursor + len(buf) <= MAX_LEN:
+            return buf
+
+    indent += INDENT_SIZE
+    buf = "{\n" + " " * indent
+    first = True
+    for key, value in dct.items():
+        if first:
+            first = False
+        else:
+            buf += ",\n" + " " * indent
+        if not isinstance(key, str):
+            raise ValueError("Illegal key type '" + type(key).__name__ + "'")
+        entry = '"' + key + '": '
+        buf += entry + _encode(value, indent, len(entry))
+    indent -= INDENT_SIZE
+    buf += "\n" + " " * indent + "}"
+
+    return buf
+
+
+def _encode(data, indent, cursor):
+    if data is None:
+        return "null"
+    elif data is True:
+        return "true"
+    elif data is False:
+        return "false"
+    elif isinstance(data, (int, float)):
+        return repr(data)
+    elif isinstance(data, str):
+        # Use the json module to escape the string with backslashes:
+        return json.dumps(data)
+    elif isinstance(data, (list, tuple)):
+        return _encode_list(data, indent, cursor)
+    elif isinstance(data, dict):
+        return _encode_dict(data, indent, cursor)
+    else:
+        raise ValueError("Illegal value type '" + type(data).__name__ + "'")
+
+
+def pretty(o, sorting_rules=None):
     if sorting_rules is not None:
         _children_sort(o, None, sorting_rules)
-
-    def _should_wrap(parent, indent):
-        assert isinstance(parent, (tuple, list, dict))
-        # We should wrap the top level collection
-        if indent == 0:
-            return True
-        if isinstance(parent, dict):
-            parent = parent.values()
-
-        count = 0
-        for child in parent:
-            if isinstance(child, (tuple, list, dict)):
-                if len(child) >= 2:
-                    count += 1
-        return count >= 2
-
-    def _encode_list(lst, indent, cursor):
-        if not lst:
-            return "[]"
-        if not _should_wrap(lst, indent):
-            buf = json.dumps(lst)
-            assert "\n" not in buf
-            if indent + cursor + len(buf) <= MAX_LEN:
-                return buf
-
-        indent += INDENT_SIZE
-        buf = "[\n" + " " * indent
-        first = True
-        for value in lst:
-            if first:
-                first = False
-            else:
-                buf += ",\n" + " " * indent
-            buf += _encode(value, indent, 0)
-        indent -= INDENT_SIZE
-        buf += "\n" + " " * indent + "]"
-
-        return buf
-
-    def _encode_dict(dct, indent, cursor):
-        if not dct:
-            return "{}"
-        if not _should_wrap(dct, indent):
-            buf = json.dumps(dct)
-            buf = "{ " + buf[1:-1] + " }"
-            assert "\n" not in buf
-            if indent + cursor + len(buf) <= MAX_LEN:
-                return buf
-
-        indent += INDENT_SIZE
-        buf = "{\n" + " " * indent
-        first = True
-        for key, value in dct.items():
-            if first:
-                first = False
-            else:
-                buf += ",\n" + " " * indent
-            if not isinstance(key, str):
-                raise ValueError("Illegal key type '" + type(key).__name__ + "'")
-            entry = '"' + key + '": '
-            buf += entry + _encode(value, indent, len(entry))
-        indent -= INDENT_SIZE
-        buf += "\n" + " " * indent + "}"
-
-        return buf
-
-    def _encode(data, indent, cursor):
-        if data is None:
-            return "null"
-        elif data is True:
-            return "true"
-        elif data is False:
-            return "false"
-        elif isinstance(data, (int, float)):
-            return repr(data)
-        elif isinstance(data, str):
-            # Use the json module to escape the string with backslashes:
-            return json.dumps(data)
-        elif isinstance(data, (list, tuple)):
-            return _encode_list(data, indent, cursor)
-        elif isinstance(data, dict):
-            return _encode_dict(data, indent, cursor)
-        else:
-            raise ValueError("Illegal value type '" + type(data).__name__ + "'")
 
     return _encode(o, 0, 0)

--- a/cfbs/pretty.py
+++ b/cfbs/pretty.py
@@ -235,6 +235,19 @@ def _should_wrap(parent, indent):
     return count >= 2
 
 
+def _encode_list_single_line(lst, indent, cursor):
+    buf = "["
+    first = True
+    for child in lst:
+        if first:
+            first = False
+        else:
+            buf += ", "
+        buf += _encode(child, indent, cursor + len(buf))
+    buf += "]"
+    return buf
+
+
 def _encode_list_multiline(lst, indent):
     indent += INDENT_SIZE
     buf = "[\n" + " " * indent
@@ -254,8 +267,7 @@ def _encode_list(lst, indent, cursor):
     if not lst:
         return "[]"
     if not _should_wrap(lst, indent):
-        buf = json.dumps(lst)
-        assert "\n" not in buf
+        buf = _encode_list_single_line(lst, indent, cursor)
         if indent + cursor + len(buf) <= MAX_LEN:
             return buf
     return _encode_list_multiline(lst, indent)

--- a/cfbs/pretty.py
+++ b/cfbs/pretty.py
@@ -273,6 +273,22 @@ def _encode_list(lst, indent, cursor):
     return _encode_list_multiline(lst, indent)
 
 
+def _encode_dict_single_line(dct, indent, cursor):
+    buf = "{ "
+    first = True
+    for key, value in dct.items():
+        if first:
+            first = False
+        else:
+            buf += ", "
+        if not isinstance(key, str):
+            raise ValueError("Illegal key type '" + type(key).__name__ + "'")
+        buf += '"' + key + '": '
+        buf += _encode(value, indent, cursor + len(buf))
+    buf += " }"
+    return buf
+
+
 def _encode_dict_multiline(dct, indent):
     indent += INDENT_SIZE
     buf = "{\n" + " " * indent
@@ -295,9 +311,7 @@ def _encode_dict(dct, indent, cursor):
     if not dct:
         return "{}"
     if not _should_wrap(dct, indent):
-        buf = json.dumps(dct)
-        buf = "{ " + buf[1:-1] + " }"
-        assert "\n" not in buf
+        buf = _encode_dict_single_line(dct, indent, cursor)
         if indent + cursor + len(buf) <= MAX_LEN:
             return buf
     return _encode_dict_multiline(dct, indent)

--- a/cfbs/pretty.py
+++ b/cfbs/pretty.py
@@ -252,12 +252,12 @@ def _encode_list_multiline(lst, indent):
     indent += INDENT_SIZE
     buf = "[\n" + " " * indent
     first = True
-    for value in lst:
+    for child in lst:
         if first:
             first = False
         else:
             buf += ",\n" + " " * indent
-        buf += _encode(value, indent, 0)
+        buf += _encode(child, indent, 0)
     indent -= INDENT_SIZE
     buf += "\n" + " " * indent + "]"
     return buf

--- a/cfbs/pretty.py
+++ b/cfbs/pretty.py
@@ -235,15 +235,7 @@ def _should_wrap(parent, indent):
     return count >= 2
 
 
-def _encode_list(lst, indent, cursor):
-    if not lst:
-        return "[]"
-    if not _should_wrap(lst, indent):
-        buf = json.dumps(lst)
-        assert "\n" not in buf
-        if indent + cursor + len(buf) <= MAX_LEN:
-            return buf
-
+def _encode_list_multiline(lst, indent):
     indent += INDENT_SIZE
     buf = "[\n" + " " * indent
     first = True
@@ -255,8 +247,18 @@ def _encode_list(lst, indent, cursor):
         buf += _encode(value, indent, 0)
     indent -= INDENT_SIZE
     buf += "\n" + " " * indent + "]"
-
     return buf
+
+
+def _encode_list(lst, indent, cursor):
+    if not lst:
+        return "[]"
+    if not _should_wrap(lst, indent):
+        buf = json.dumps(lst)
+        assert "\n" not in buf
+        if indent + cursor + len(buf) <= MAX_LEN:
+            return buf
+    return _encode_list_multiline(lst, indent)
 
 
 def _encode_dict(dct, indent, cursor):

--- a/cfbs/pretty.py
+++ b/cfbs/pretty.py
@@ -261,16 +261,7 @@ def _encode_list(lst, indent, cursor):
     return _encode_list_multiline(lst, indent)
 
 
-def _encode_dict(dct, indent, cursor):
-    if not dct:
-        return "{}"
-    if not _should_wrap(dct, indent):
-        buf = json.dumps(dct)
-        buf = "{ " + buf[1:-1] + " }"
-        assert "\n" not in buf
-        if indent + cursor + len(buf) <= MAX_LEN:
-            return buf
-
+def _encode_dict_multiline(dct, indent):
     indent += INDENT_SIZE
     buf = "{\n" + " " * indent
     first = True
@@ -285,8 +276,19 @@ def _encode_dict(dct, indent, cursor):
         buf += entry + _encode(value, indent, len(entry))
     indent -= INDENT_SIZE
     buf += "\n" + " " * indent + "}"
-
     return buf
+
+
+def _encode_dict(dct, indent, cursor):
+    if not dct:
+        return "{}"
+    if not _should_wrap(dct, indent):
+        buf = json.dumps(dct)
+        buf = "{ " + buf[1:-1] + " }"
+        assert "\n" not in buf
+        if indent + cursor + len(buf) <= MAX_LEN:
+            return buf
+    return _encode_dict_multiline(dct, indent)
 
 
 def _encode(data, indent, cursor):

--- a/cfbs/pretty.py
+++ b/cfbs/pretty.py
@@ -266,7 +266,7 @@ def pretty(o, sorting_rules=None):
             return "{}"
         if not _should_wrap(dct, indent):
             buf = json.dumps(dct)
-            buf = "{ " + buf[1 : len(buf) - 1] + " }"
+            buf = "{ " + buf[1:-1] + " }"
             assert "\n" not in buf
             if indent + cursor + len(buf) <= MAX_LEN:
                 return buf

--- a/tests/test_pretty.py
+++ b/tests/test_pretty.py
@@ -516,3 +516,86 @@ def test_pretty_sorting_real_examples():
 }"""
 
     assert pretty_string(test_json, cfbs_sorting_rules) == expected
+
+
+def test_pretty_same_as_npm_prettier():
+    # We saw some cases where cfbs pretty and npm prettier did not agree
+    # Testing that this is no longer the case
+
+    test_json = """
+    {
+      "classes": { "My_class": {}, "My_class2": {"comment": "comment body"} }
+    }
+    """
+
+    expected = """{
+  "classes": { "My_class": {}, "My_class2": { "comment": "comment body" } }
+}"""
+
+    assert pretty_string(test_json) == expected
+
+    test_json = """
+    {
+      "filter": {
+        "filter": { "Attribute name": {"operator": "value2"} },
+        "hostFilter": {
+          "includes": {
+            "includeAdditionally": false,
+            "entries": {
+              "ip": ["192.168.56.5"],
+              "hostkey": [],
+              "hostname": ["ubuntu-bionic"],
+              "mac": ["08:00:27:0b:a4:99", "08:00:27:dd:e1:59", "02:9f:d3:59:7e:90"],
+              "ip_mask": ["10.0.2.16/16"]
+            }
+          },
+          "excludes": {
+            "entries": {
+              "ip": [],
+              "hostkey": [],
+              "hostname": [],
+              "mac": [],
+              "ip_mask": []
+            }
+          }
+        },
+        "hostContextExclude": ["class_value"],
+        "hostContextInclude": ["class_value"]
+      }
+    }
+    """
+
+    expected = """{
+  "filter": {
+    "filter": { "Attribute name": { "operator": "value2" } },
+    "hostFilter": {
+      "includes": {
+        "includeAdditionally": false,
+        "entries": {
+          "ip": ["192.168.56.5"],
+          "hostkey": [],
+          "hostname": ["ubuntu-bionic"],
+          "mac": [
+            "08:00:27:0b:a4:99",
+            "08:00:27:dd:e1:59",
+            "02:9f:d3:59:7e:90"
+          ],
+          "ip_mask": ["10.0.2.16/16"]
+        }
+      },
+      "excludes": {
+        "entries": {
+          "ip": [],
+          "hostkey": [],
+          "hostname": [],
+          "mac": [],
+          "ip_mask": []
+        }
+      }
+    },
+    "hostContextExclude": ["class_value"],
+    "hostContextInclude": ["class_value"]
+  }
+}"""
+
+    assert pretty_string(test_json) == expected


### PR DESCRIPTION
- **pretty.py: removed unnecessary call to len()**
- **pretty.py: un-nested functions to decrease complexity**
- **pretty.py: split encoding of list into two functions**
- **pretty.py: split encoding of dict into two functions**
- **pretty.py: implemented single line encoder for lists**
- **pretty.py: implemented single line encoder for dict**
- **pretty.py: renamed a variable**
- **pretty.py: line length wrapping takes comma into consideration**
- **Added unit tests comparing cfbs pretty with output from npm prettier**
